### PR TITLE
Decrease timers for noble stress events

### DIFF
--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -331,7 +331,7 @@
 	desc = "<span class='red'>I slept on the floor. It was uncomfortable.</span>"
 
 /datum/stress_event/sleepfloornoble
-	timer = 3 MINUTES
+	timer = 1 MINUTES
 	stress_change = 4
 	desc = "<span class='red'>I slept on the floor! What am I, an animal?!</span>"
 
@@ -404,17 +404,17 @@
 /datum/stress_event/noble_impoverished_food
 	stress_change = 3
 	desc = span_boldred("This is disgusting. How can anyone eat this?")
-	timer = 10 MINUTES
+	timer = 1 MINUTES
 
 /datum/stress_event/noble_desperate
 	stress_change = 6
 	desc = span_boldred("What level of desperation have I fallen to?")
-	timer = 60 MINUTES
+	timer = 5 MINUTES
 
 /datum/stress_event/noble_bland_food
 	stress_change = 2
 	desc = span_red("This fare is really beneath me. I deserve better than this...")
-	timer = 5 MINUTES
+	timer = 2 MINUTES
 
 /datum/stress_event/tortured/on_apply(mob/living/user)
 	. = ..()
@@ -424,32 +424,32 @@
 /datum/stress_event/noble_bad_manners
 	stress_change = 1
 	desc = span_red("I should've used a spoon...")
-	timer = 5 MINUTES
+	timer = 1 MINUTES
 
 /datum/stress_event/noble_ate_without_table
 	stress_change = 1
 	desc = span_red("Eating such a meal without a table? Churlish.")
-	timer = 5 MINUTES
+	timer = 2 MINUTES
 
 /datum/stress_event/noble_ate_without_plate
 	stress_change = 1
 	desc = span_red("To eat without a plate... how utterly uncivilized.")
-	timer = 5 MINUTES
+	timer = 2 MINUTES
 
 /datum/stress_event/noble_ate_with_just_a_fork
 	stress_change = 1
 	desc = span_red("Eating off a bare fork, this is hardly proper dining.")
-	timer = 5 MINUTES
+	timer = 2 MINUTES
 
 /datum/stress_event/noble_tarnished_cloth
 	stress_change = 1
 	desc = span_red("This is beneath me... a noble should dry their cloth in a proper place.")
-	timer = 5 MINUTES
+	timer = 2 MINUTES
 
 /datum/stress_event/noble_polishing_shoe
 	stress_change = 3
 	desc = span_red("This menial chore insults my station, i should not need to polish a pair of shoes.")
-	timer = 5 MINUTES
+	timer = 3 MINUTES
 
 /datum/stress_event/destroyed_past //gaffer destroying their trophies
 	stress_change = 4


### PR DESCRIPTION
Reduced timers for various noble stress events to enhance gameplay pacing.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Noble blooded feels more like a negative event as is, it should be less annoying for nobles overall honestly.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Noble fun.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: noble stress event durations reduced to more sensible times.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [X] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
