### PR TITLE
Fix message magic 65_1

### DIFF
--- a/code/modules/spells/spell_types/undirected/message.dm
+++ b/code/modules/spells/spell_types/undirected/message.dm
@@ -36,6 +36,12 @@
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)
 		return
+
+	// Resetting variables before each cast
+	recipient_ref = null
+	message = null
+	anonymous = FALSE
+
 	if(!LAZYLEN(owner.mind?.known_people))
 		to_chat(owner, span_warning("I don't know anyone!"))
 		return . | SPELL_CANCEL_CAST
@@ -72,17 +78,23 @@
 
 /datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
 	. = ..()
-	var/mob/living/recipient = recipient_ref.resolve()
-	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [message]", LOG_GAME)
+
+/datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
+	. = ..()
+	// Saving values to local variables
+	var/datum/weakref/temp_ref = recipient_ref
+	var/temp_message = message
+	var/temp_anonymous = anonymous
+
+	var/mob/living/recipient = temp_ref?.resolve()
+
+	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [temp_message]", LOG_GAME)
 	if(QDELETED(recipient))
 		return
 	if(!recipient.mind)
 		return
-	if(anonymous && (recipient.STAPER >= 15))
+	if(temp_anonymous && (recipient.STAPER >= 15))
 		if(recipient.mind?.do_i_know(name = owner.real_name))
-			to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into [owner]'s voice: <font color=#7246ff>[message]</font>")
+			to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into [owner]'s voice: <font color=#7246ff>[temp_message]</font>")
 			return
-	to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into an unknown [owner.gender == FEMALE ? "woman" : "man"]'s voice: <font color=#7246ff>[message]</font>")
-
-
-
+	to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into an unknown [owner.gender == FEMALE ? "woman" : "man"]'s voice: <font color=#7246ff>[temp_message]</font>")

--- a/code/modules/spells/spell_types/undirected/message.dm
+++ b/code/modules/spells/spell_types/undirected/message.dm
@@ -78,16 +78,12 @@
 
 /datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
 	. = ..()
-
-/datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
-	. = ..()
 	// Saving values to local variables
 	var/datum/weakref/temp_ref = recipient_ref
 	var/temp_message = message
 	var/temp_anonymous = anonymous
 
 	var/mob/living/recipient = temp_ref?.resolve()
-
 	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [temp_message]", LOG_GAME)
 	if(QDELETED(recipient))
 		return


### PR DESCRIPTION
## О запросе на извлечение

Ремонт отправки сообщений арканой 

## Почему это полезно для игры

Мы получаем рабочую аркану отправки сообщений

:cl:
fix: Ремонт отправки сообщений заклинанием message
:cl:

## Журнал изменений

Переменные recipient_ref, message и anonymous хранятся как поля объекта заклинания и не сбрасываются между кастами. Первый раз, выбирая получателя, он СОХРАНЯЕТСЯ в recipient_ref, и при следующем касте используется тот же самый получатель, даже если выбрать нового.

Нужно перенести логику выбора получателя и сообщения непосредственно в cast(), а не хранить их в полях объекта.

Метод решения
1. Сбросить хранимые переменные при новом касте. 
2. Добавить новую переменную, собирающую временный лог отправляемого сообщения.

## !!!ВАЖНО!!!
## !НЕ ПРОТЕСТИРОВАННО!
билд запускается. Рантаймов и ошибок не обнаружено при касте. У меня почему-то вылетает билд когда я хочу перезайти в меню, гостаюсь из персонажа, тыкаю слева икноку "померить" и лювлю вылет. 
Если вы знаете как сделать так чтоб клиент не вылетал, то прошу подсказать в комментариях ниже.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.