### PR TITLE
FIX: message magic 67 2

### DIFF
--- a/code/modules/spells/spell_types/undirected/message.dm
+++ b/code/modules/spells/spell_types/undirected/message.dm
@@ -36,6 +36,12 @@
 	. = ..()
 	if(. & SPELL_CANCEL_CAST)
 		return
+
+	// Resetting variables before each cast
+	recipient_ref = null
+	message = null
+	anonymous = FALSE
+
 	if(!LAZYLEN(owner.mind?.known_people))
 		to_chat(owner, span_warning("I don't know anyone!"))
 		return . | SPELL_CANCEL_CAST
@@ -72,17 +78,23 @@
 
 /datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
 	. = ..()
-	var/mob/living/recipient = recipient_ref.resolve()
-	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [message]", LOG_GAME)
+
+/datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
+	. = ..()
+	// Saving values to local variables
+	var/datum/weakref/temp_ref = recipient_ref
+	var/temp_message = message
+	var/temp_anonymous = anonymous
+
+	var/mob/living/recipient = temp_ref?.resolve()
+
+	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [temp_message]", LOG_GAME)
 	if(QDELETED(recipient))
 		return
 	if(!recipient.mind)
 		return
-	if(anonymous && (recipient.STAPER >= 15))
+	if(temp_anonymous && (recipient.STAPER >= 15))
 		if(recipient.mind?.do_i_know(name = owner.real_name))
-			to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into [owner]'s voice: <font color=#7246ff>[message]</font>")
+			to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into [owner]'s voice: <font color=#7246ff>[temp_message]</font>")
 			return
-	to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into an unknown [owner.gender == FEMALE ? "woman" : "man"]'s voice: <font color=#7246ff>[message]</font>")
-
-
-
+	to_chat(recipient, "Arcyne whispers fill the back of my head, resolving into an unknown [owner.gender == FEMALE ? "woman" : "man"]'s voice: <font color=#7246ff>[temp_message]</font>")

--- a/code/modules/spells/spell_types/undirected/message.dm
+++ b/code/modules/spells/spell_types/undirected/message.dm
@@ -78,16 +78,12 @@
 
 /datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
 	. = ..()
-
-/datum/action/cooldown/spell/undirected/message/cast(atom/cast_on)
-	. = ..()
 	// Saving values to local variables
 	var/datum/weakref/temp_ref = recipient_ref
 	var/temp_message = message
 	var/temp_anonymous = anonymous
 
 	var/mob/living/recipient = temp_ref?.resolve()
-
 	owner.log_message("[key_name(owner)] sent a spell message to [key_name(recipient)]; message: [temp_message]", LOG_GAME)
 	if(QDELETED(recipient))
 		return


### PR DESCRIPTION
## О запросе на извлечение

Ремонт доставки арканных сообщений

## Почему это полезно для игры

Мы получаем рабочий скил

:cl:
fix: Ремонт отправки сообщений заклинанием message
:cl:

## Журнал изменений

Переменные recipient_ref, message и anonymous хранятся как поля объекта заклинания и не сбрасываются между кастами. 
При первом использовании информация СОХРАНЯЕТСЯ в recipient_ref, и при следующем касте используется сохранённый набор данных, даже если указывать новые данные.

Метод решения этого PR:
1. Сбросить хранимые переменные при новом касте. 

##  ПРОТЕСТИРОВАННО И ГОТОВО!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.