### PR TITLE
FIX: Wings of Dendor

### DIFF
--- a/code/modules/spells/spell_types/pointed/projectile/falcon_disrupt.dm
+++ b/code/modules/spells/spell_types/pointed/projectile/falcon_disrupt.dm
@@ -106,6 +106,9 @@
 			to_chat(M, span_nicegreen("A falcon swoops low and drops [send_item.name] before you!"))
 
 /obj/effect/falcon_messenger/proc/cleanup()
+	send_item = null
+	target_turf = null
+	recipient = null
 	qdel(src)
 
 /obj/projectile/magic/falcon_dive


### PR DESCRIPTION
## О запросе на извлечение

Ремонт скилла Wings of Dendor

## Почему это полезно для игры

Мы получаем рабочий скилл

:cl:
fix: Ремонт третьей функции скилла Wings of Dendor
:cl:

## Журнал изменений

Проблема в том, что в текущей реализации falcon_messenger сохраняет начальные значения target_turf и recipient при создании и не обновляет их при повторном использовании. Нужно очистить эти переменные после завершения доставки или перед новой.

Метод решения
1. Сбросить хранимые переменные при новом касте. 


##  ПРОТЕСТИРОВАННО И ГОТОВО!

У скилла всё ещё не работает вторая функция - Отправить предмет заклинателю - себе. Позже починю постараюсь.

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.