### PR TITLE
BALANCE: phantom_ear_buff_1

### DIFF
--- a/code/game/objects/items/phantom_ear.dm
+++ b/code/game/objects/items/phantom_ear.dm
@@ -7,7 +7,7 @@
 	icon_state = "ear_ring"
 	invisibility = INVISIBILITY_LEYLINES
 	w_class = WEIGHT_CLASS_TINY
-	var/hear_radius = 2
+	var/hear_radius = 6
 	var/muted = FALSE
 	var/datum/weakref/linked_living
 

--- a/code/modules/spells/spell_types/pointed/conjure/phantom_ear.dm
+++ b/code/modules/spells/spell_types/pointed/conjure/phantom_ear.dm
@@ -16,6 +16,7 @@
 
 	summon_type = list(/obj/item/phantom_ear)
 	summon_radius = 0
+	cast_range = 14
 
 	var/datum/weakref/current_ear
 


### PR DESCRIPTION
## О запросе на извлечение

Обновление способности phantom_ear

## Почему это полезно для игры

Хорошенько попользовавшись IC данным скиллом - выяснилось:
- нельзя кинуть при взгляде в даль
- размер зоны прослушки ОЧЕНЬ маленкий!!
- довольно бесполезен в существующем варианте

Обновлённый вариант скилла из данного PR делает его буквально юзабельным и чуть более интересным, действительно выполняющим свою функцию.

:cl:
add: Added more things
balance: rebalanced something
fix: fixed a few things
:cl:

## Журнал изменений

var/hear_radius = 6 - Слышимость теперь немного меньше чем обычный радиус обзора
cast_range = 14 - возможность броска на дистанцию взгляда в даль / через shift + пкм

##  ПРОТЕСТИРОВАННО И ГОТОВО!

Всё остальное в этом скиле прекрасно и работоспособно, потому не трогано
С остальными скиллами конфликтов нет. (радиус использования изменяется только в VV / касте этого скилла)

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
---------------------------




