### PR TITLE
Runtime hunt

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -83,12 +83,12 @@
 
 //#define FORCE_RANDOM_WORLD_GEN
 
-#define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it.
+//#define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it.
 
-#define NO_DUNGEON //comment this to load dungeons.
+//#define NO_DUNGEON //comment this to load dungeons.
 
 //#define USES_PQ
-#define ABSOLUTE_MINIMUM_MODE //uncomment this to skip as many resource intensive ops as possible to load in for testing the fastest while preserving most gameplay features.
+//#define ABSOLUTE_MINIMUM_MODE //uncomment this to skip as many resource intensive ops as possible to load in for testing the fastest while preserving most gameplay features.
 
 #ifdef LOWMEMORYMODE
 #ifdef ABSOLUTE_MINIMUM_MODE

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -83,12 +83,12 @@
 
 //#define FORCE_RANDOM_WORLD_GEN
 
-//#define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it.
+#define LOWMEMORYMODE //uncomment this to load centcom and roguetest and thats it.
 
-//#define NO_DUNGEON //comment this to load dungeons.
+#define NO_DUNGEON //comment this to load dungeons.
 
 //#define USES_PQ
-//#define ABSOLUTE_MINIMUM_MODE //uncomment this to skip as many resource intensive ops as possible to load in for testing the fastest while preserving most gameplay features.
+#define ABSOLUTE_MINIMUM_MODE //uncomment this to skip as many resource intensive ops as possible to load in for testing the fastest while preserving most gameplay features.
 
 #ifdef LOWMEMORYMODE
 #ifdef ABSOLUTE_MINIMUM_MODE

--- a/modular_rmh/code/datums/traits/_quirk.dm
+++ b/modular_rmh/code/datums/traits/_quirk.dm
@@ -18,6 +18,7 @@
 	..()
 	if(!quirk_mob || (human_only && !ishuman(quirk_mob)) || quirk_mob.has_quirk(type))
 		qdel(src)
+		return
 	quirk_holder = quirk_mob
 	SSquirks.quirk_objects += src
 	to_chat(quirk_holder, gain_text)
@@ -28,7 +29,9 @@
 	add()
 	if(spawn_effects)
 		on_spawn()
-		addtimer(CALLBACK(src, PROC_REF(post_add)), 30)
+		if(!QDELETED(src))
+			addtimer(CALLBACK(src, PROC_REF(post_add)), 30)
+
 
 /datum/quirk/Destroy()
 	STOP_PROCESSING(SSquirks, src)
@@ -52,8 +55,8 @@
 
 /datum/quirk/proc/reapply()
 	if(revive_reapply)
-		on_spawn()
-		addtimer(CALLBACK(src, PROC_REF(post_add)), 30)
+		if(!QDELETED(src))
+			addtimer(CALLBACK(src, PROC_REF(post_add)), 30)
 
 /datum/quirk/proc/add() //special "on add" effects
 /datum/quirk/proc/on_spawn() //these should only trigger when the character is being created for the first time, i.e. roundstart/latejoin


### PR DESCRIPTION
<img width="990" height="360" alt="image" src="https://github.com/user-attachments/assets/f447742b-e675-4a9e-8626-82a1cb6c8aff" />

stack_trace() — это диагностический хелпер, созданный для принудительного получения call stack,
НЕ прерывая текущую логику кода вручную.

Как мы видим из лога, у нас куча похожих рантаймов.

## Why It's Good For The Game

Runtime fixes

## Changelog
1) Квирки
stack trace("addtimer called with a callbac...")
addtimer(/datum/callback (/datum/callback), 30, 0, "modular_rmh/code/datums/traits...", 31)
 
Проблема в том, что в datum/quirk/New() ставится addtimer() на сам quirk (src),
а quirk может быть удалён (qdel) раньше, чем таймер успеет привязаться или выполниться.

Интермиттирующе воспроизводится при большом количестве квирков, например:
Sensitiveness, No Pouch, Picky Sleeper, Wild Night, Jesterphobic,
Heavy Sleeper, Ageusia, Bookworm, Noble Lineage,
Unarmed Training, Sword Training

Добавлены защитные проверки, запрещающие установку таймера на уже удалённый quirk:
- добавлен ранний return после qdel(src) в New()
- addtimer() теперь вызывается только если quirk не помечен к удалению

:cl:
fix: fixed a few things
code: changed some code
/:cl:

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
