### PR TITLE
Stealth PR Postfixes

### DIFF
--- a/code/datums/ai/_ai_controller.dm
+++ b/code/datums/ai/_ai_controller.dm
@@ -447,7 +447,7 @@ have ways of interacting with a specific atom and control it. They posses a blac
 			if(isliving(current_movement_target))
 				var/mob/living/living_pawn = pawn
 				var/mob/living/living_target = current_movement_target
-				if(living_target.rogue_sneaking)
+				if(living_target.alpha <= 100 || living_target.rogue_sneaking)
 					if(!living_pawn.npc_detect_sneak(living_target, 0))
 						failed_sneak_check++
 				else

--- a/code/datums/ai/behaviours/hostile/find_highest_aggro.dm
+++ b/code/datums/ai/behaviours/hostile/find_highest_aggro.dm
@@ -96,7 +96,7 @@
 		if(!targetting_datum.can_quickly_engage_target(living_mob, pot_target))
 			continue
 		// Skip sneaking mobs with a chance to detect them
-		if(pot_target.rogue_sneaking)
+		if(pot_target.alpha <= 100 || pot_target.rogue_sneaking)
 			var/extra_chance = (living_mob.health <= living_mob.maxHealth * 0.5) ? 30 : 0
 			if(!living_mob.npc_detect_sneak(pot_target, extra_chance))
 				continue
@@ -172,7 +172,7 @@
 		var/mob/living/living_target = checking
 		if(living_target.stat == DEAD)
 			return FALSE
-		if(living_target.rogue_sneaking)
+		if(living_target.alpha <= 100 || living_target.rogue_sneaking)
 			var/mob/living/living_pawn = pawn
 			var/extra_chance = (living_pawn.health <= living_pawn.maxHealth * 0.5) ? 30 : 0
 			if(!living_pawn.npc_detect_sneak(living_target, extra_chance))

--- a/code/datums/ai/behaviours/hostile/find_potential_targets.dm
+++ b/code/datums/ai/behaviours/hostile/find_potential_targets.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(target_interested_atoms, typecacheof(list(/mob)))
 		if(living_target.stat == DEAD)
 			filtered_targets -= living_target
 			continue
-		if(!living_target.rogue_sneaking)
+		if(!living_target.alpha > 100 || !living_target.rogue_sneaking)
 			continue
 		var/extra_chance = (living_mob.health <= living_mob.maxHealth * 50) ? 30 : 0 // if we're below half health, we're way more alert
 		if (!living_mob.npc_detect_sneak(living_target, extra_chance))

--- a/code/datums/ai/behaviours/hostile/find_priority_targets.dm
+++ b/code/datums/ai/behaviours/hostile/find_priority_targets.dm
@@ -50,7 +50,7 @@
 				break
 
 	for(var/mob/living/living_target in filtered_targets)
-		if(!living_target.rogue_sneaking)
+		if(!living_target.alpha <= 100 || !living_target.rogue_sneaking)
 			continue
 		var/extra_chance = (living_mob.health <= living_mob.maxHealth * 50) ? 30 : 0 // if we're below half health, we're way more alert
 		if (!living_mob.npc_detect_sneak(living_target, extra_chance))

--- a/code/datums/ai/targetting_datum/simpe_targetting_datum.dm
+++ b/code/datums/ai/targetting_datum/simpe_targetting_datum.dm
@@ -354,6 +354,8 @@
 			return FALSE
 	if(living_mob.see_invisible < the_target.invisibility)//Target's invisible to us, forget it
 		return FALSE
+	if(living_mob.alpha <= 100 || living_mob.rogue_sneaking)
+		return FALSE
 
 	if(isturf(the_target.loc) && living_mob.z != the_target.z)
 		return FALSE

--- a/code/datums/rts/attacking_strategy/_base.dm
+++ b/code/datums/rts/attacking_strategy/_base.dm
@@ -50,7 +50,7 @@
 /datum/worker_attack_strategy/proc/on_target_selection(mob/living/target)
 	if(!isliving(target))
 		return
-	if(target.alpha == 0 && target.rogue_sneaking)
+	if(target.alpha <= 100 && target.rogue_sneaking)
 		return worker.npc_detect_sneak(target, simple_detect_bonus)
 
 /datum/worker_attack_strategy/proc/pick_target(list/possible_targets)

--- a/code/datums/sex/actions/_base_action.dm
+++ b/code/datums/sex/actions/_base_action.dm
@@ -407,7 +407,6 @@
 	return TRUE
 
 /datum/sex_action/proc/on_perform(mob/living/user, mob/living/target)
-	. = ..()
 	sex_volume = initial(sex_volume)
 	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
 		sex_volume *= 0.5

--- a/code/datums/sex/actions/_base_action.dm
+++ b/code/datums/sex/actions/_base_action.dm
@@ -401,9 +401,16 @@
 			if(!try_store_in_hole(user, target))
 				return FALSE
 	lock_sex_object(user, target)
+	sex_volume = initial(sex_volume)
+	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
+		sex_volume *= 0.5
 	return TRUE
 
 /datum/sex_action/proc/on_perform(mob/living/user, mob/living/target)
+	. = ..()
+	sex_volume = initial(sex_volume)
+	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
+		sex_volume *= 0.5
 	return
 
 /datum/sex_action/proc/on_finish(mob/living/user, mob/living/target)
@@ -418,6 +425,9 @@
 		else
 			remove_from_hole(user, target)
 	unlock_sex_object(user, target)
+	sex_volume = initial(sex_volume)
+	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
+		sex_volume *= 0.5
 	return
 
 /datum/sex_action/proc/is_finished(mob/living/user, mob/living/target)

--- a/code/datums/sex/actions/hole_storage/expel_foreign_fluids.dm
+++ b/code/datums/sex/actions/hole_storage/expel_foreign_fluids.dm
@@ -65,6 +65,7 @@
 	)
 
 /datum/sex_action/hole_storage/expel_foreign_fluids/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/obj/item/organ/genitals/filling_organ/filling_organ = get_action_organ(user, target)
 	if(!filling_organ)
 		to_chat(user, span_warning("There is nothing to clear right now."))

--- a/code/datums/sex/actions/hole_storage/storage_anus.dm
+++ b/code/datums/sex/actions/hole_storage/storage_anus.dm
@@ -40,13 +40,11 @@
 		target_organ = target.getorganslot(hole_id)
 		user.visible_message(span_warning("[user] starts inserting \the [dildo] in [target]'s ass..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/anus_store/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 4 //base pain amt to use
 	var/self = (user == target)
 	if(!target_organ)
@@ -170,13 +168,12 @@
 		target_organ = target.getorganslot(hole_id)
 		user.visible_message(span_warning("[user] starts removing items from [target]'s ass..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/anus_remove/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 2 //base pain amt to use
 
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
@@ -250,13 +247,12 @@
 
 	to_chat(user, span_warning("I brace myself and start pushing out items from deep inside my ass..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/anus_remove_deep/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 1 //base pain amt to use
 
 	if(!target_organ)

--- a/code/datums/sex/actions/hole_storage/storage_vaginal.dm
+++ b/code/datums/sex/actions/hole_storage/storage_vaginal.dm
@@ -40,13 +40,12 @@
 		target_organ = target.getorganslot(hole_id)
 		user.visible_message(span_warning("[user] starts inserting \the [dildo] in [target]'s pussy..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/vagina_store/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 2 //base pain amt to use
 	var/self = (user == target)
 	if(!target_organ)
@@ -170,13 +169,12 @@
 		target_organ = target.getorganslot(hole_id)
 		user.visible_message(span_warning("[user] starts removing items from [target]'s pussy..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/vagina_remove/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 1 //base pain amt to use
 
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
@@ -250,13 +248,12 @@
 
 	to_chat(user, span_warning("I brace myself and start pushing out items from deep inside my pussy..."))
 
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 
 /datum/sex_action/hole_storage/vagina_remove_deep/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/pain_amt = 1 //base pain amt to use
 
 	if(!target_organ)

--- a/code/datums/sex/actions/masturbation/anus.dm
+++ b/code/datums/sex/actions/masturbation/anus.dm
@@ -23,6 +23,7 @@
 	user.visible_message(span_warning("[user] starts fingering [user.p_their()] butt..."))
 
 /datum/sex_action/masturbate/anus/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message())
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [user.p_their()] butt..."))

--- a/code/datums/sex/actions/masturbation/breasts.dm
+++ b/code/datums/sex/actions/masturbation/breasts.dm
@@ -26,6 +26,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [user.p_their()] breasts..."))
 
 /datum/sex_action/masturbate/breasts/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fondles [user.p_their()] breasts..."))

--- a/code/datums/sex/actions/masturbation/clit_rub.dm
+++ b/code/datums/sex/actions/masturbation/clit_rub.dm
@@ -25,6 +25,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [user.p_their()] clit..."))
 
 /datum/sex_action/masturbate/clit_rub/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "rubs"
 	var/arousal_amt = 2.2
@@ -90,6 +91,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [target]'s clit..."))
 
 /datum/sex_action/masturbate/other/clit_rub/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "rubs"
 	var/arousal_amt = 2.2

--- a/code/datums/sex/actions/masturbation/finger_vagina.dm
+++ b/code/datums/sex/actions/masturbation/finger_vagina.dm
@@ -29,6 +29,7 @@
 	user.visible_message(span_warning("[user] starts fingering [user.p_their()] [pick("slit","cunt","pussy","snatch")]..."))
 
 /datum/sex_action/masturbate/vagina_finger/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [user.p_their()] [pick("slit","cunt","pussy","snatch")]..."))

--- a/code/datums/sex/actions/masturbation/labia.dm
+++ b/code/datums/sex/actions/masturbation/labia.dm
@@ -25,6 +25,7 @@
 	user.visible_message(span_warning("[user] starts playing with [user.p_their()] labia..."))
 
 /datum/sex_action/masturbate/labia/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "tugs at"
 	var/arousal_amt = 1.2
@@ -87,6 +88,7 @@
 	user.visible_message(span_warning("[user] starts playing with [target]'s labia..."))
 
 /datum/sex_action/masturbate/other/labia/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "tugs at"
 	var/arousal_amt = 1.2

--- a/code/datums/sex/actions/masturbation/nipples.dm
+++ b/code/datums/sex/actions/masturbation/nipples.dm
@@ -26,6 +26,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [user.p_their()] nipples..."))
 
 /datum/sex_action/masturbate/nipples/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "rubs"
 	var/arousal_amt = 1.0
@@ -86,6 +87,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [target]'s nipples..."))
 
 /datum/sex_action/masturbate/other/nipples/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/action_text = "rubs"
 	var/arousal_amt = 1.0

--- a/code/datums/sex/actions/masturbation/other/anus.dm
+++ b/code/datums/sex/actions/masturbation/other/anus.dm
@@ -24,6 +24,7 @@
 	user.visible_message(span_warning("[user] starts fingering [target]'s butt..."))
 
 /datum/sex_action/masturbate/other/anus/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [target]'s butt..."))

--- a/code/datums/sex/actions/masturbation/other/breasts.dm
+++ b/code/datums/sex/actions/masturbation/other/breasts.dm
@@ -26,6 +26,7 @@
 	user.visible_message(span_warning("[user] starts rubbing [target]'s breasts..."))
 
 /datum/sex_action/masturbate/other/breasts/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fondles [target]'s breasts..."))

--- a/code/datums/sex/actions/masturbation/other/clit.dm
+++ b/code/datums/sex/actions/masturbation/other/clit.dm
@@ -26,6 +26,7 @@
 	user.visible_message(span_warning("[user] starts stroking [target]'s clit..."))
 
 /datum/sex_action/masturbate/other/clit/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] strokes [target]'s clit..."))

--- a/code/datums/sex/actions/masturbation/other/penis.dm
+++ b/code/datums/sex/actions/masturbation/other/penis.dm
@@ -28,6 +28,7 @@
 	user.visible_message(span_warning("[user] starts jerking [target]'s off..."))
 
 /datum/sex_action/masturbate/other/penis/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock off..."))

--- a/code/datums/sex/actions/masturbation/other/vagina.dm
+++ b/code/datums/sex/actions/masturbation/other/vagina.dm
@@ -30,6 +30,7 @@
 	user.visible_message(span_warning("[user] starts fingering [target]'s [pick("slit","cunt","pussy","snatch")]..."))
 
 /datum/sex_action/masturbate/other/vagina/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fingers [target]'s [pick("slit","cunt","pussy","snatch")]..."))

--- a/code/datums/sex/actions/masturbation/penis.dm
+++ b/code/datums/sex/actions/masturbation/penis.dm
@@ -29,6 +29,7 @@
 	user.visible_message(span_warning("[user] starts jerking off..."))
 
 /datum/sex_action/masturbate/penis/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	if(can_show_action_message(user, target))

--- a/code/datums/sex/actions/masturbation/penis_over.dm
+++ b/code/datums/sex/actions/masturbation/penis_over.dm
@@ -32,6 +32,7 @@
 	user.visible_message(span_warning("[user] starts jerking over [target]..."))
 
 /datum/sex_action/masturbate/penis_over/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/chosen_verb = pick(list("jerks [user.p_their()] cock", "strokes [user.p_their()] cock", "masturbates", "jerks off"))
 	if(can_show_action_message(user, target))

--- a/code/datums/sex/actions/masturbation/slap_breasts.dm
+++ b/code/datums/sex/actions/masturbation/slap_breasts.dm
@@ -28,6 +28,7 @@
 	user.visible_message(span_warning("[user] raises [user.p_their()] hand over [user.p_their()] breasts..."))
 
 /datum/sex_action/masturbate/slap_breasts/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')
 	var/action_text = "slaps"
@@ -92,6 +93,7 @@
 	user.visible_message(span_warning("[user] raises [user.p_their()] hand over [target]'s breasts..."))
 
 /datum/sex_action/masturbate/other/slap_breasts/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')
 	var/action_text = "slaps"

--- a/code/datums/sex/actions/masturbation/slap_pussy.dm
+++ b/code/datums/sex/actions/masturbation/slap_pussy.dm
@@ -27,6 +27,7 @@
 	user.visible_message(span_warning("[user] raises [user.p_their()] hand over [user.p_their()] [pick("slit", "cunt", "pussy", "snatch")]..."))
 
 /datum/sex_action/masturbate/slap_pussy/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')
 	var/action_text = "slaps"
@@ -92,6 +93,7 @@
 	user.visible_message(span_warning("[user] raises [user.p_their()] hand over [target]'s [pick("slit", "cunt", "pussy", "snatch")]..."))
 
 /datum/sex_action/masturbate/other/slap_pussy/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')
 	var/action_text = "slaps"

--- a/code/datums/sex/actions/masturbation/vagina.dm
+++ b/code/datums/sex/actions/masturbation/vagina.dm
@@ -25,6 +25,7 @@
 	user.visible_message(span_warning("[user] starts stroking [user.p_their()] clit..."))
 
 /datum/sex_action/masturbate/vagina/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] strokes [user.p_their()] clit..."))

--- a/code/datums/sex/actions/npc/npc_facesitting.dm
+++ b/code/datums/sex/actions/npc/npc_facesitting.dm
@@ -32,6 +32,7 @@
 
 
 /datum/sex_action/npc/npc_facesitting/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/verbstring = pick(list("rubs", "smushes", "forces"))
 	if(can_show_action_message(user, target))

--- a/code/datums/sex/actions/npc/npc_rimming.dm
+++ b/code/datums/sex/actions/npc/npc_rimming.dm
@@ -30,6 +30,7 @@
 	user.visible_message(span_warning("[user] starts rimming [target]'s butt..."))
 
 /datum/sex_action/npc/npc_rimming/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rims [target]'s butt..."))

--- a/code/datums/sex/actions/npc/npc_throat_sex.dm
+++ b/code/datums/sex/actions/npc/npc_throat_sex.dm
@@ -25,6 +25,7 @@
 	return TRUE
 
 /datum/sex_action/npc/npc_throat_sex/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s throat."))

--- a/code/datums/sex/actions/oral/armpit_nuzzle.dm
+++ b/code/datums/sex/actions/oral/armpit_nuzzle.dm
@@ -27,6 +27,7 @@
 	user.visible_message(span_warning("[user] moves [user.p_their()] head against [target]'s armpit..."))
 
 /datum/sex_action/armpit_nuzzle/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] nuzzles [target]'s armpit..."))

--- a/code/datums/sex/actions/oral/blowjob.dm
+++ b/code/datums/sex/actions/oral/blowjob.dm
@@ -45,6 +45,7 @@
 	user.visible_message(span_warning("[user] starts sucking [target]'s cock..."))
 
 /datum/sex_action/blowjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	user.make_sucking_noise()
 	do_thrust_animate(user, target)

--- a/code/datums/sex/actions/oral/crotch_nuzzle.dm
+++ b/code/datums/sex/actions/oral/crotch_nuzzle.dm
@@ -27,6 +27,7 @@
 	user.visible_message(span_warning("[user] moves [user.p_their()] head against [target]'s crotch..."))
 
 /datum/sex_action/crotch_nuzzle/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] nuzzles [target]'s crotch..."))

--- a/code/datums/sex/actions/oral/cunnilingus.dm
+++ b/code/datums/sex/actions/oral/cunnilingus.dm
@@ -35,6 +35,7 @@
 	user.visible_message(span_warning("[user] starts sucking [target]'s clit..."))
 
 /datum/sex_action/cunnilingus/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s clit..."))

--- a/code/datums/sex/actions/oral/foot_lick.dm
+++ b/code/datums/sex/actions/oral/foot_lick.dm
@@ -30,6 +30,7 @@
 	user.visible_message(span_warning("[user] starts licking [target]'s feet..."))
 
 /datum/sex_action/foot_lick/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] licks [target]'s feet..."))

--- a/code/datums/sex/actions/oral/kissing.dm
+++ b/code/datums/sex/actions/oral/kissing.dm
@@ -30,6 +30,7 @@
 	user.visible_message(span_warning("[user] starts making out with [target]..."))
 
 /datum/sex_action/kissing/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] makes out with [target]..."))

--- a/code/datums/sex/actions/oral/rimming.dm
+++ b/code/datums/sex/actions/oral/rimming.dm
@@ -30,6 +30,7 @@
 	user.visible_message(span_warning("[user] starts rimming [target]'s butt..."))
 
 /datum/sex_action/rimming/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rims [target]'s butt..."))

--- a/code/datums/sex/actions/oral/suck_balls.dm
+++ b/code/datums/sex/actions/oral/suck_balls.dm
@@ -34,6 +34,7 @@
 	user.visible_message(span_warning("[user] starts sucking [target]'s balls..."))
 
 /datum/sex_action/suck_balls/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s balls..."))

--- a/code/datums/sex/actions/oral/suck_nipples.dm
+++ b/code/datums/sex/actions/oral/suck_nipples.dm
@@ -34,6 +34,7 @@
 	user.visible_message(span_warning("[user] starts sucking [target]'s nipples..."))
 
 /datum/sex_action/suck_nipples/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] sucks [target]'s nipples..."))

--- a/code/datums/sex/actions/other/facesitting.dm
+++ b/code/datums/sex/actions/other/facesitting.dm
@@ -36,6 +36,7 @@
 	user.visible_message(span_warning("[user] sits [user.p_their()] butt on [target]'s face!"))
 
 /datum/sex_action/facesitting/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/verbstring = pick(list("rubs", "smushes", "forces"))
 	if(can_show_action_message(user, target))

--- a/code/datums/sex/actions/other/frotting.dm
+++ b/code/datums/sex/actions/other/frotting.dm
@@ -37,6 +37,7 @@
 	user.visible_message(span_warning("[user] shoves [user.p_their()] cock against [target]'s own!"))
 
 /datum/sex_action/frotting/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] frots cocks together with [target]."))

--- a/code/datums/sex/actions/other/rub_body.dm
+++ b/code/datums/sex/actions/other/rub_body.dm
@@ -23,6 +23,7 @@
 	user.visible_message(span_warning("[user] places [user.p_their()] hands onto [target]..."))
 
 /datum/sex_action/rub_body/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] rubs [target]'s body..."))

--- a/code/datums/sex/actions/other/spanking.dm
+++ b/code/datums/sex/actions/other/spanking.dm
@@ -31,6 +31,7 @@
 	user.visible_message(span_warning("[user] positions [user.p_their()] hand to spank [target]'s butt!"))
 
 /datum/sex_action/spanking/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	var/force = sex_session.force
 	var/sound = pick('sound/foley/slap.ogg', 'sound/foley/smackspecial.ogg')

--- a/code/datums/sex/actions/other/tongue_bath.dm
+++ b/code/datums/sex/actions/other/tongue_bath.dm
@@ -27,6 +27,7 @@
 	user.visible_message(span_warning("[user] sticks [user.p_their()] tongue out, getting close to [target]..."))
 
 /datum/sex_action/tonguebath/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] bathes [target]'s body with [user.p_their()] tongue..."))

--- a/code/datums/sex/actions/other/wax_play.dm
+++ b/code/datums/sex/actions/other/wax_play.dm
@@ -88,6 +88,7 @@
 	user.visible_message(span_warning("[user] tilts the candle over [target]'s chest..."))
 
 /datum/sex_action/wax_play/breasts/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	apply_wax_effects(user, target, "breasts", 1.2, 2.5)
 
 /datum/sex_action/wax_play/breasts/on_finish(mob/living/user, mob/living/target)
@@ -120,6 +121,7 @@
 	user.visible_message(span_warning("[user] tilts the candle over [target]'s rear..."))
 
 /datum/sex_action/wax_play/butt/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	apply_wax_effects(user, target, "butt", 1.0, 2.0)
 
 /datum/sex_action/wax_play/butt/on_finish(mob/living/user, mob/living/target)

--- a/code/datums/sex/actions/sex/boobjob.dm
+++ b/code/datums/sex/actions/sex/boobjob.dm
@@ -37,6 +37,7 @@
 	user.visible_message(span_warning("[user] grabs [target]'s tits and shoves [user.p_their()] cock inbetween!"))
 
 /datum/sex_action/sex/boobjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s tits."))

--- a/code/datums/sex/actions/sex/other/boobjob.dm
+++ b/code/datums/sex/actions/sex/other/boobjob.dm
@@ -38,6 +38,7 @@
 	target.visible_message(span_warning("[target] shoves [user]'s cock between [user.p_their()] tits!"))
 
 /datum/sex_action/sex/other/boobjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		target.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s tits."))

--- a/code/datums/sex/actions/sex/other/footjob.dm
+++ b/code/datums/sex/actions/sex/other/footjob.dm
@@ -37,6 +37,7 @@
 	user.visible_message(span_warning("[user] puts [user.p_their()] feet on [target]'s cock..."))
 
 /datum/sex_action/sex/other/footjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] feet..."))

--- a/code/datums/sex/actions/sex/other/thighjob.dm
+++ b/code/datums/sex/actions/sex/other/thighjob.dm
@@ -32,6 +32,7 @@
 	user.visible_message(span_warning("[user] moves [user.p_their()] thighs between [target]'s cock..."))
 
 /datum/sex_action/sex/other/thighjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] jerks [target]'s cock with [user.p_their()] thighs..."))

--- a/code/datums/sex/actions/sex/scissoring.dm
+++ b/code/datums/sex/actions/sex/scissoring.dm
@@ -38,6 +38,7 @@
 	user.visible_message(span_warning("[user] spreads [user.p_their()] legs and aligns [user.p_their()] cunt against [target]'s own!"))
 
 /datum/sex_action/scissoring/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] scissors with [target]'s cunt."))

--- a/code/datums/sex/actions/sex/thighjob.dm
+++ b/code/datums/sex/actions/sex/thighjob.dm
@@ -33,6 +33,7 @@
 	user.visible_message(span_warning("[user] grabs [target]'s thighs and shoves [user.p_their()] cock inbetween!"))
 
 /datum/sex_action/sex/thighjob/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s thighs."))

--- a/code/datums/sex/actions/sex/vaginal.dm
+++ b/code/datums/sex/actions/sex/vaginal.dm
@@ -33,19 +33,16 @@
 /datum/sex_action/sex/vaginal/on_start(mob/living/user, mob/living/target)
 	. = ..()
 	user.visible_message(span_warning("[user] slides [user.p_their()] cock into [target]'s pussy!"))
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), used_sex_volume, TRUE, ignore_walls = FALSE)
+
+	playsound(target, list('sound/misc/mat/insert (1).ogg','sound/misc/mat/insert (2).ogg'), sex_volume, TRUE, ignore_walls = FALSE)
 
 /datum/sex_action/sex/vaginal/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/sex_session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(sex_session.spanify_force("[user] [sex_session.get_generic_force_adjective()] fucks [target]'s pussy."))
-	var/used_sex_volume = sex_volume
-	if(user.rogue_sneaking || user.m_intent == MOVE_INTENT_SNEAK || user.alpha <= 100)
-		used_sex_volume *= 0.5
-	playsound(target, sex_session.get_force_sound(), used_sex_volume, TRUE, -2, ignore_walls = FALSE)
+
+	playsound(target, sex_session.get_force_sound(), sex_volume, TRUE, -2, ignore_walls = FALSE)
 	do_thrust_animate(user, target)
 
 	if(user.has_kink(KINK_ONOMATOPOEIA))

--- a/code/datums/sex/custom_actions.dm
+++ b/code/datums/sex/custom_actions.dm
@@ -544,6 +544,7 @@ GLOBAL_LIST_INIT(sex_custom_action_templates, build_sex_custom_action_templates(
 	return TRUE
 
 /datum/sex_action/custom/on_perform(mob/living/user, mob/living/target)
+	. = ..()
 	var/datum/sex_session/session = get_sex_session(user, target)
 	if(can_show_action_message(user, target))
 		user.visible_message(session.spanify_force(get_custom_message(message_tick, user, target, "{user} keeps {name} going.")))

--- a/code/datums/sex/sex_procs.dm
+++ b/code/datums/sex/sex_procs.dm
@@ -561,6 +561,8 @@
 	var/show_genitals = FALSE
 	var/mouth_blocked = FALSE
 
+	COOLDOWN_DECLARE(npc_sneak_detect_cd)
+
 /mob/living/Initialize()
 	. = ..()
 	refresh_erp_preference_cache()

--- a/code/modules/mob/living/accuracy_checks.dm
+++ b/code/modules/mob/living/accuracy_checks.dm
@@ -55,6 +55,12 @@
 /proc/calculate_hit_chance(zone, mob/living/user, mob/living/target, associated_skill, datum/intent/used_intent, obj/item/I)
 	var/chance2hit = 0
 
+	//resting or attacks from behind / stealth are more likely to hit.
+	if(target.body_position == LYING_DOWN)
+		chance2hit += 10
+	if(user && (target.dir == turn(get_dir(target,user), 180 || user.alpha <= 15)))
+		chance2hit += 20
+
 	if(check_zone(zone) == zone)
 		chance2hit += 10
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -222,7 +222,7 @@
 	if(statforce)
 		next_attack_msg.Cut()
 		affecting.bodypart_attacked_by(user.used_intent.blade_class, statforce, crit_message = TRUE)
-		if(!can_see_cone(user) || user.alpha < 15)//Dreamkeep change
+		if(!can_see_cone(user) || user.alpha < 15)//From Dreamkeep
 			if(user.mind && !HAS_TRAIT(src, TRAIT_BLINDFIGHTING) && !user.has_status_effect(/datum/status_effect/debuff/stealthcd))
 				var/sneakmult = user.get_skill_level(/datum/skill/misc/sneaking)
 				statforce *= max(1,sneakmult)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -152,6 +152,7 @@
 
 	if (prob(probby))
 		// whoops it saw us
+		target.apply_status_effect(/datum/status_effect/debuff/stealthcd)
 		MOBTIMER_SET(target, MT_FOUNDSNEAK)
 		to_chat(target, span_danger("[src] sees me! I'm found!"))
 		target.update_sneak_invis(TRUE)

--- a/code/modules/mob/living/carbon/human/npc/_npc.dm
+++ b/code/modules/mob/living/carbon/human/npc/_npc.dm
@@ -128,11 +128,16 @@
 
 
 /mob/living/proc/npc_detect_sneak(mob/living/target, extra_prob = 0)
-	if (target.alpha > 100 || !target.rogue_sneaking)
+	if (target.alpha > 100)
+		return TRUE
+	if(!COOLDOWN_FINISHED(src, npc_sneak_detect_cd))
+		return FALSE
+	COOLDOWN_START(src, npc_sneak_detect_cd, 8 SECONDS) //this shit happens every process normally
+	if(target.alpha > 100) // this used to have rogue_sneaking too but i think its used for full darkness invisibility now.
 		return TRUE
 	if(HAS_TRAIT(target, TRAIT_IMPERCEPTIBLE))
 		return FALSE
-	var/probby = 2 * GET_MOB_ATTRIBUTE_VALUE(src, STAT_PERCEPTION) //this is 10 by default - npcs get an easier time to detect to slightly thwart cheese
+	var/probby = 3 * GET_MOB_ATTRIBUTE_VALUE(src, STAT_PERCEPTION) //this is 10 by default
 	probby += extra_prob
 	var/sneak_bonus = 0
 	if(target.mind)
@@ -141,7 +146,7 @@
 			sneak_bonus = (max(GET_MOB_SKILL_VALUE_OLD(target, /datum/attribute/skill/magic/arcane), GET_MOB_SKILL_VALUE_OLD(target, /datum/attribute/skill/magic/holy)) * 10)
 			probby -= 20 // also just a fat lump of extra difficulty for the npc since spells are hard, you know?
 		else
-			sneak_bonus = (GET_MOB_SKILL_VALUE_OLD(target, /datum/attribute/skill/misc/sneaking) * 5)
+			sneak_bonus = (GET_MOB_SKILL_VALUE_OLD(target, /datum/attribute/skill/misc/sneaking) * 10)
 		probby -= sneak_bonus
 
 	probby += 100 * target.get_encumbrance()

--- a/code/modules/surgery/bodyparts/bodypart_wounds.dm
+++ b/code/modules/surgery/bodyparts/bodypart_wounds.dm
@@ -207,9 +207,9 @@
 	var/from_behind = FALSE
 	if(user && (owner.dir == turn(get_dir(owner,user), 180)))
 		from_behind = TRUE
-	if(owner.resting)
+	if(owner.body_position == LYING_DOWN)
 		dam += 15
-	if(user && (from_behind || user.alpha <= 15))//Dreamkeep change -- Attacks from stealth should be much more likely to crit
+	if(user && (from_behind || user.alpha <= 15))//From Dreamkeep -- Attacks from stealth should be much more likely to crit
 		if(user.mind && !HAS_TRAIT(owner, TRAIT_BLINDFIGHTING) && !user.has_status_effect(/datum/status_effect/debuff/stealthcd))
 			var/sneakmult = user.get_skill_level(/datum/skill/misc/sneaking)
 			dam *= max(1,sneakmult)
@@ -318,9 +318,9 @@
 	var/from_behind = FALSE
 	if(user && (owner.dir == turn(get_dir(owner,user), 180)))
 		from_behind = TRUE
-	if(owner.resting)
+	if(owner.body_position == LYING_DOWN)
 		dam += 15
-	if(user && (from_behind || user.alpha <= 15))//Dreamkeep change -- Attacks from stealth should be much more likely to crit
+	if(user && (from_behind || user.alpha <= 15))//From Dreamkeep -- Attacks from stealth should be much more likely to crit
 		if(user.mind && !HAS_TRAIT(owner, TRAIT_BLINDFIGHTING) && !user.has_status_effect(/datum/status_effect/debuff/stealthcd))
 			var/sneakmult = user.get_skill_level(/datum/skill/misc/sneaking)
 			dam *= max(1,sneakmult)
@@ -434,9 +434,9 @@
 	var/from_behind = FALSE
 	if(user && (owner.dir == turn(get_dir(owner,user), 180)))
 		from_behind = TRUE
-	if(owner.resting)
+	if(owner.body_position == LYING_DOWN)
 		dam += 15
-	if(user && (from_behind || user.alpha <= 15))//Dreamkeep change -- Attacks from stealth should be much more likely to crit
+	if(user && (from_behind || user.alpha <= 15))//From Dreamkeep -- Attacks from stealth should be much more likely to crit
 		if(user.mind && !HAS_TRAIT(owner, TRAIT_BLINDFIGHTING) && !user.has_status_effect(/datum/status_effect/debuff/stealthcd))
 			var/sneakmult = user.get_skill_level(/datum/skill/misc/sneaking)
 			dam *= max(1,sneakmult)

--- a/modular_rmh/code/datums/ai/horny_ai/horny_ai_datums.dm
+++ b/modular_rmh/code/datums/ai/horny_ai/horny_ai_datums.dm
@@ -246,7 +246,7 @@
 		var/mob/living/living_target = target
 		if(living_target.stat == DEAD)
 			return FALSE
-		if(living_target.rogue_sneaking)
+		if(living_target.alpha <= 100 || living_target.rogue_sneaking)
 			var/extra_chance = (basic_mob.health <= basic_mob.maxHealth * 0.5) ? 30 : 0
 			if(!basic_mob.npc_detect_sneak(living_target, extra_chance))
 				return FALSE

--- a/modular_rmh/code/datums/ai/horny_ai/horny_subtrees.dm
+++ b/modular_rmh/code/datums/ai/horny_ai/horny_subtrees.dm
@@ -91,9 +91,12 @@
 		var/mob/living/living_target = target
 		if(living_target.stat == DEAD)
 			return FALSE
-		if(living_target.rogue_sneaking)
+		if(living_target.alpha <= 100 || living_target.rogue_sneaking)
+			return FALSE
+			/* leave this for normal checks to expose instead of double checking i guess.
 			var/extra_chance = (living_pawn.health <= living_pawn.maxHealth * 0.5) ? 30 : 0
 			if(!living_pawn.npc_detect_sneak(living_target, extra_chance))
 				return FALSE
+			*/
 
 	return TRUE

--- a/modular_rmh/code/datums/ai/horny_ai/horny_subtrees.dm
+++ b/modular_rmh/code/datums/ai/horny_ai/horny_subtrees.dm
@@ -92,11 +92,8 @@
 		if(living_target.stat == DEAD)
 			return FALSE
 		if(living_target.alpha <= 100 || living_target.rogue_sneaking)
-			return FALSE
-			/* leave this for normal checks to expose instead of double checking i guess.
 			var/extra_chance = (living_pawn.health <= living_pawn.maxHealth * 0.5) ? 30 : 0
 			if(!living_pawn.npc_detect_sneak(living_target, extra_chance))
 				return FALSE
-			*/
 
 	return TRUE

--- a/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/assassin.dm
+++ b/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/assassin.dm
@@ -34,6 +34,9 @@
 
 	attribute_sheet = /datum/attribute_holder/sheet/job/advclass/combat/adventurer_rogue/assassin
 
+	spells = list(
+		/datum/action/cooldown/spell/undirected/rogue_vanish
+	)
 
 	traits = list(
 		TRAIT_ASSASSIN,

--- a/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/calishite_assasin.dm
+++ b/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/calishite_assasin.dm
@@ -39,6 +39,10 @@
 
 	languages = list(/datum/language/zalad)
 
+	spells = list(
+		/datum/action/cooldown/spell/undirected/rogue_vanish
+	)
+
 /datum/outfit/adventurer_rogue/calishite_assasin
 	name = "Calishite Assasin"
 	head = /obj/item/clothing/neck/keffiyeh/colored/red

--- a/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/thief.dm
+++ b/modular_rmh/code/modules/jobs/job_types/adventurers/rogue_types/thief.dm
@@ -43,6 +43,10 @@
 
 	languages = list(/datum/language/thievescant)
 
+	spells = list(
+		/datum/action/cooldown/spell/undirected/rogue_vanish
+	)
+
 /datum/outfit/adventurer_rogue/thief
 	name = "Thief"
 	head = null

--- a/modular_rmh/code/modules/spells/spell_types/undirected/rogue_smokebomb.dm
+++ b/modular_rmh/code/modules/spells/spell_types/undirected/rogue_smokebomb.dm
@@ -16,6 +16,7 @@
 	associated_skill = /datum/skill/misc/sneaking
 	cooldown_reduction_per_rank = 2 SECONDS
 
+//not low alpha enough to sneak attack without going behind.
 /datum/action/cooldown/spell/undirected/rogue_vanish/cast(mob/living/carbon/human/user)
 	. = ..()
 	new /obj/effect/particle_effect/smoke(get_turf(user))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
Some things I forgot,
Makes stealth and backstabs or attacks on laying people more likely to hit where intended and overall hit at all.
Makes stealth cd on mobs work right
Makes mobs odds to find stealth same as players and have sensible cooldown to perception checks instead of every goddamn process, Idk how much perception baseline humans would have but allegedly mobs have 10, and with same odds to both sides it should be fair i think, besides they get extra odds when hurt still, plus we got stealth cooldown now so it should be fine.
Gives the vanish ability to thief and assassin classes
stealth smex noise should work right now hopefully
still cant make hornyai respect stealth, seaweed AAAAAAAAAAAAAAAAAA