### PR TITLE
NycteaLust QoL №1

### DIFF
--- a/code/datums/components/storage/storage_grid_types.dm
+++ b/code/datums/components/storage/storage_grid_types.dm
@@ -332,7 +332,7 @@
 	insert_preposition = "on"
 
 /datum/component/storage/concrete/grid/food/cooking/pot
-	screen_max_rows = 3
+	screen_max_rows = 4
 	screen_max_columns = 3
 	insert_verb = "put"
 	insert_preposition = "in"

--- a/code/game/objects/items/plate.dm
+++ b/code/game/objects/items/plate.dm
@@ -8,7 +8,7 @@
 	possible_item_intents = list(/datum/intent/use, /datum/intent/food)
 	w_class = WEIGHT_CLASS_NORMAL
 	///How many things fit on this plate?
-	var/max_items = 2
+	var/max_items = 4
 	///The offset from side to side the food items can have on the plate
 	var/max_x_offset = 4
 	///The max height offset the food can reach on the plate

--- a/code/game/objects/items/storage/cook_kit.dm
+++ b/code/game/objects/items/storage/cook_kit.dm
@@ -1,5 +1,5 @@
 /datum/component/storage/concrete/grid/messkit
-	screen_max_rows = 2
+	screen_max_rows = 4
 	screen_max_columns = 5
 	max_w_class = WEIGHT_CLASS_BULKY
 	not_while_equipped = TRUE
@@ -22,6 +22,8 @@
 	populate_contents = list(
 		/obj/item/plate,
 		/obj/item/reagent_containers/glass/bowl,
+		/obj/item/reagent_containers/glass/bottle/waterskin,
+		/obj/item/reagent_containers/glass/bucket/pot/copper,
 		/obj/item/cooking/pan,
 		/obj/item/mobilestove,
 		/obj/item/folding_table_stored

--- a/code/modules/reagents/reagent_containers/bucket_pot.dm
+++ b/code/modules/reagents/reagent_containers/bucket_pot.dm
@@ -73,6 +73,7 @@
 	drop_sound = 'sound/foley/dropsound/shovel_drop.ogg'
 	melting_material = /datum/material/iron
 	melt_amount = 80
+	volume = 200
 	var/processing_amount = 0 ///we use this to "reserve" reagents
 	var/static/list/recipe_list = list()
 
@@ -90,10 +91,12 @@
 /obj/item/reagent_containers/glass/bucket/pot/copper
 	icon_state = "pote_copper"
 	melting_material = /datum/material/copper
+	volume = 100
 
 /obj/item/reagent_containers/glass/bucket/pot/stone
 	icon_state = "pote_stone"
 	melting_material = null
+	volume = 50
 
 /obj/item/reagent_containers/glass/bucket/pot/attackby(obj/item/I, mob/user, list/modifiers)
 	if(istype(I, /obj/item/reagent_containers/glass/bowl))


### PR DESCRIPTION

## About The Pull Request

Quality of Life фичи для походов/готовки, изменения по удобству и просьбе игроков.
Тарелки - Увеличено количество слотов до 4
Чаны - Увеличено количество слотов до 4 на 3, Железный 100литров -> 200; Медный 100литров-> 100; Каменный 100литров -> 50.
Messkit(я хзы как на русском) - увеличено количество слотов до 4 на 5, добавлен медный котел и бурдюк.

Quality of Life for hiking / cooking, changes according to the convenience and request of the players.
Plates - Increased the number of slots to 4
Pots - Increased the number of slots to 4 by 3, Iron 100 liters -> 200; Copper 100 liters-> 100; Stone 100 liters -> 50.
Messkit - the number of slots has been increased to 4 by 5, a copper pot and a wineskin have been added.
## Why It's Good For The Game

Давно игроки жаловались на чаны для супов и их скудность, чуть облегчила им жизнь.
Сделала походный набор более полезный теперь в нем больше слотов для тарелок и утвари.

For a long time, the players complained about the soup vats and their scarcity, which made their lives a little easier.
I made the camping kit more useful, now it has more slots for plates and utensils.

## Changelog


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
