### PR TITLE
Nyctea lust fix void dragon

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/deepones.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/deepones.dm
@@ -13,7 +13,7 @@
 	base_strength = 13
 	base_speed = 9
 	maxHealth = DEEPONE_HEALTH
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 5, /obj/item/alch/viscera = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/triton = 5, /obj/item/alch/viscera = 2)
 	health = DEEPONE_HEALTH
 	harm_intent_damage = 20
 	melee_damage_lower = 10

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/void_dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/summons/void/void_dragon.dm
@@ -41,7 +41,7 @@
 	aggressive = 1
 	deathmessage = "collapses to the floor with a final roar, the impact rocking the ground."
 	footstep_type = FOOTSTEP_MOB_HEAVY
-	var/void_corruption = TRUE
+	var/void_corruption = FALSE
 	dendor_taming_chance = DENDOR_TAME_PROB_NONE
 	food_max = 0
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Временно отключен Void Corrupt у дракона, на тестах появление болезни не было замечено.
Void Corruption was temporarily disabled in the dragon, the appearance of the disease was not noticed in the tests.
## Why It's Good For The Game

Void Corrupt во многом не подходим нашему серверу, при этом он сломан.

## Changelog

Я изменила TRUE на FALSE я молодец, убрано накладывания состояния Void Corrupt
I changed TRUE to FALSE, well done, the Void Corrupt state overlay has been removed.

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
del: Void Corruption
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
