### PR TITLE
Desc_hint для контекстной инфо квирков | Desc_hint var for quirk context info

### DIFF
--- a/code/datums/quirks/_base.dm
+++ b/code/datums/quirks/_base.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(quirk_points_by_type)
 			"name" = initial(quirk_type.name),
 			"type" = quirk_type,
 			"desc" = initial(quirk_type.desc),
+			"desc_hint" = initial(quirk_type.desc_hint),
 			"value" = initial(quirk_type.point_value)
 		))
 		LAZYADDASSOC(GLOB.quirk_singletons, quirk_type, new quirk_type)
@@ -56,6 +57,8 @@ GLOBAL_LIST_EMPTY(quirk_points_by_type)
 	var/name = "Quirk"
 	/// Description of what this quirk does
 	var/desc = "A quirk."
+	/// Optional hint to show below the desc, for OOC or important info
+	var/desc_hint = ""
 	/// Category: QUIRK_BOON, QUIRK_VICE, or QUIRK_PECULIARITY
 	var/quirk_category = QUIRK_PECULIARITY
 	/// Point value (negative = costs points, positive = gives points)
@@ -120,6 +123,9 @@ GLOBAL_LIST_EMPTY(quirk_points_by_type)
 
 /datum/quirk/proc/get_desc(datum/preferences/prefs)
 	return desc
+
+/datum/quirk/proc/get_desc_hint(datum/preferences/prefs)
+	return desc_hint
 
 /datum/quirk/proc/after_job_spawn(datum/job/job)
 	return

--- a/code/datums/quirks/boon/backstory.dm
+++ b/code/datums/quirks/boon/backstory.dm
@@ -1,6 +1,7 @@
 /datum/quirk/boon/backstory
 	name = "Experienced Background"
-	desc = "You had a previous career before becoming an adventurer. You've retained skills from that time, but it left its mark on you. (OOC NOTE; COMBAT SKILLS ARE CLAMPED AT AVERAGE FROM THIS, THIS IS YOUR PAST.)"
+	desc = "You had a previous career before becoming an adventurer. You've retained skills from that time, but it left its mark on you."
+	desc_hint = "(Combat skills are clamped at average from this, this is your past)"
 	point_value = -2
 	customization_label = "Choose Background"
 	customization_options = list()

--- a/code/datums/quirks/boon/backstory.dm
+++ b/code/datums/quirks/boon/backstory.dm
@@ -1,7 +1,7 @@
 /datum/quirk/boon/backstory
 	name = "Experienced Background"
 	desc = "You had a previous career before becoming an adventurer. You've retained skills from that time, but it left its mark on you."
-	desc_hint = "(Combat skills are clamped at average from this, this is your past)"
+	desc_hint = "Combat skills are clamped at average from this, this is your past"
 	point_value = -2
 	customization_label = "Choose Background"
 	customization_options = list()

--- a/code/datums/quirks/peculiarity/_peculiarity.dm
+++ b/code/datums/quirks/peculiarity/_peculiarity.dm
@@ -245,5 +245,6 @@
 
 /datum/quirk/peculiarity/selfawaregeni
 	name = "Sensitiveness"
-	desc = "I can tell more about my private bits (may be spammy, exact liquid information and alerts etc.)"
+	desc = "I can tell more about my private bits."
+	desc_hint = "(May be spammy, exact liquid information and alerts e.t.c.)"
 	point_value = 0

--- a/code/datums/quirks/peculiarity/_peculiarity.dm
+++ b/code/datums/quirks/peculiarity/_peculiarity.dm
@@ -246,5 +246,5 @@
 /datum/quirk/peculiarity/selfawaregeni
 	name = "Sensitiveness"
 	desc = "I can tell more about my private bits."
-	desc_hint = "(May be spammy, exact liquid information and alerts e.t.c.)"
+	desc_hint = "May be spammy, exact liquid information and alerts e.t.c."
 	point_value = 0

--- a/code/datums/quirks/vices/physical_vice.dm
+++ b/code/datums/quirks/vices/physical_vice.dm
@@ -71,7 +71,7 @@
 /datum/quirk/vice/tongueless
 	name = "Tongueless"
 	desc = "I said one word too many to a noble, they cut out my tongue."
-	desc_hint = "(Being mute is not an excuse to forego roleplay. Use of custom emotes is recommended)"
+	desc_hint = "Being mute is not an excuse to forego roleplay. Use of custom emotes is recommended"
 	point_value = 4
 
 /datum/quirk/vice/tongueless/on_spawn()

--- a/code/datums/quirks/vices/physical_vice.dm
+++ b/code/datums/quirks/vices/physical_vice.dm
@@ -70,7 +70,8 @@
 
 /datum/quirk/vice/tongueless
 	name = "Tongueless"
-	desc = "I said one word too many to a noble, they cut out my tongue. (Being mute is not an excuse to forego roleplay. Use of custom emotes is recommended.)"
+	desc = "I said one word too many to a noble, they cut out my tongue."
+	desc_hint = "(Being mute is not an excuse to forego roleplay. Use of custom emotes is recommended)"
 	point_value = 4
 
 /datum/quirk/vice/tongueless/on_spawn()

--- a/code/datums/quirks/vices/special.dm
+++ b/code/datums/quirks/vices/special.dm
@@ -1,10 +1,10 @@
 
 /datum/quirk/vice/wanted
 	name = "Wanted"
-	desc = "Something in my past has made me a target. I am marked as an outlaw in these lands. I'm always looking over my shoulder. And protecting my loins...	\
-	\nTHIS IS A DIFFICULT FLAW, YOU WILL BE HUNTED AND HAVE NON-CON AND RAPE ATTEMPTS MADE AGAINST YOU BY TOWN GUARDS. \
-	THIS DOES NOT GIVE YOU A LICENSE TO GRIEF OR PERFORM CRIMINAL ACTS WITH IMPUNITY, \
-	THIS IS A ROLEPLAY FLAW TO MAKE YOU A 'TARGET' - PLAY AT YOUR OWN RISK."
+	desc = "Something in my past has made me a target. I am marked as an outlaw in these lands. I'm always looking over my shoulder. And protecting my loins..."
+	desc_hint = "THIS IS A DIFFICULT FLAW, YOU WILL BE HUNTED AND HAVE NON-CON AND RAPE ATTEMPTS MADE AGAINST YOU BY TOWN GUARDS. \
+	This does not give you a license to grief or perform criminal acts with impunity, \
+	This is a roleplay flaw to make you a 'target' - play at your own risk."
 	point_value = 3
 	customization_type = QUIRK_TEXT
 	customization_label = "Why are you being hunted?"
@@ -30,6 +30,7 @@
 	if(HAS_TRAIT(user, TRAIT_RECOGNIZE_ADDICTS))
 		LAZYADDASSOCLIST(examine_contents, EXAMINE_SECT_PREGEAR, span_info("A wanted person..."))
 
+/*
 /datum/quirk/vice/luxless
 	name = "Lux-less"
 	desc = "Through some grand misfortune, or heroic sacrifice - you have given up your link to Psydon, and with it - your soul. A putrid, horrid thing, you consign yourself to an eternity of nil after death. EXPECT A DIFFICULT, MECHANICALLY UNFAIR EXPERIENCE. (Rakshari, Hollowkin and Kobolds cannot take this - they already have no lux.)"
@@ -43,6 +44,7 @@
 		/datum/species/goblin,
 		/datum/species/orc,
 	)
+*/
 
 /datum/quirk/vice/luxless/on_examined(mob/user, list/P, list/examine_contents)
 	if(HAS_TRAIT(user, TRAIT_RECOGNIZE_ADDICTS))
@@ -288,7 +290,8 @@
 
 /datum/quirk/vice/weak_heart
 	name = "Weak Heart"
-	desc = "You were born with a weak heart. You can't handle stressful situations for fear of your heart giving out (Half threshold for heart attacks and heart attack from being overly stressed)."
+	desc = "You were born with a weak heart. You can't handle stressful situations for fear of your heart giving out."
+	desc_hint = "(Half threshold for heart attacks and heart attack from being overly stressed)"
 	point_value = 6
 	incompatible_quirks = list(
 		/datum/quirk/boon/iron_will

--- a/code/datums/quirks/vices/special.dm
+++ b/code/datums/quirks/vices/special.dm
@@ -2,10 +2,10 @@
 /datum/quirk/vice/wanted
 	name = "Wanted"
 	desc = "Something in my past has made me a target. I am marked as an outlaw in these lands. I'm always looking over my shoulder. And protecting my loins..."
-	desc_hint = "THIS IS A DIFFICULT FLAW. \
+	desc_hint = "THIS IS A DIFFICULT FLAW - play at your own risk. \
 	<br>You will be hunted and have non-con and rape attempts made against you by town guards. \
-	<br>This does not give you a license to grief or perform criminal acts with impunity, \
-	this is a roleplay flaw to make you a 'target' - play at your own risk"
+	This does not give you a license to grief or perform criminal acts with impunity, \
+	this is a roleplay flaw to make you a 'target'"
 	point_value = 3
 	customization_type = QUIRK_TEXT
 	customization_label = "Why are you being hunted?"
@@ -45,7 +45,6 @@
 		/datum/species/goblin,
 		/datum/species/orc,
 	)
-*/
 
 /datum/quirk/vice/luxless/on_examined(mob/user, list/P, list/examine_contents)
 	if(HAS_TRAIT(user, TRAIT_RECOGNIZE_ADDICTS))
@@ -56,6 +55,7 @@
 		return
 	var/mob/living/carbon/human/H = owner
 	H.apply_status_effect(/datum/status_effect/debuff/flaw_lux_taken)
+*/
 
 /datum/quirk/vice/pacifist
 	name = "Pacifist"

--- a/code/datums/quirks/vices/special.dm
+++ b/code/datums/quirks/vices/special.dm
@@ -2,9 +2,10 @@
 /datum/quirk/vice/wanted
 	name = "Wanted"
 	desc = "Something in my past has made me a target. I am marked as an outlaw in these lands. I'm always looking over my shoulder. And protecting my loins..."
-	desc_hint = "THIS IS A DIFFICULT FLAW, YOU WILL BE HUNTED AND HAVE NON-CON AND RAPE ATTEMPTS MADE AGAINST YOU BY TOWN GUARDS. \
-	This does not give you a license to grief or perform criminal acts with impunity, \
-	This is a roleplay flaw to make you a 'target' - play at your own risk."
+	desc_hint = "THIS IS A DIFFICULT FLAW. \
+	<br>You will be hunted and have non-con and rape attempts made against you by town guards. \
+	<br>This does not give you a license to grief or perform criminal acts with impunity, \
+	this is a roleplay flaw to make you a 'target' - play at your own risk"
 	point_value = 3
 	customization_type = QUIRK_TEXT
 	customization_label = "Why are you being hunted?"
@@ -291,7 +292,7 @@
 /datum/quirk/vice/weak_heart
 	name = "Weak Heart"
 	desc = "You were born with a weak heart. You can't handle stressful situations for fear of your heart giving out."
-	desc_hint = "(Half threshold for heart attacks and heart attack from being overly stressed)"
+	desc_hint = "Half threshold for heart attacks and heart attack from being overly stressed"
 	point_value = 6
 	incompatible_quirks = list(
 		/datum/quirk/boon/iron_will

--- a/code/datums/quirks/vices/special.dm
+++ b/code/datums/quirks/vices/special.dm
@@ -30,7 +30,7 @@
 	if(HAS_TRAIT(user, TRAIT_RECOGNIZE_ADDICTS))
 		LAZYADDASSOCLIST(examine_contents, EXAMINE_SECT_PREGEAR, span_info("A wanted person..."))
 
-/*
+/* THIS QUIRK ISN'T LIABLE FOR RIVERMIST HOLLOW BUILD
 /datum/quirk/vice/luxless
 	name = "Lux-less"
 	desc = "Through some grand misfortune, or heroic sacrifice - you have given up your link to Psydon, and with it - your soul. A putrid, horrid thing, you consign yourself to an eternity of nil after death. EXPECT A DIFFICULT, MECHANICALLY UNFAIR EXPERIENCE. (Rakshari, Hollowkin and Kobolds cannot take this - they already have no lux.)"

--- a/code/modules/client/preferences/preferences_quirks.dm
+++ b/code/modules/client/preferences/preferences_quirks.dm
@@ -438,6 +438,7 @@
 		dat += "<span class='quirk-points'>[quirk_data["value"]] pts</span>"
 		dat += "</div>"
 		dat += "<div class='quirk-desc'>[quirk_data["desc"]]</div>"
+		dat += "<div class='quirk-desc_hint'>[quirk_data["desc_hint"]]</div>"
 
 		if(is_selected)
 			dat += "<div class='quirk-status'>Selected</div>"
@@ -473,6 +474,7 @@
 		dat += "<span class='quirk-points'>[quirk.point_value] pts</span>"
 		dat += "</div>"
 		dat += "<div class='quirk-desc'>[quirk.get_desc(src)]</div>"
+		dat += "<div class='quirk-desc_hint'>[quirk.get_desc_hint(src)]</div>"
 
 		var/custom_type = quirk.customization_type
 		var/list/options = quirk?.return_customization(src)

--- a/html/browser/quirk_menu.css
+++ b/html/browser/quirk_menu.css
@@ -279,6 +279,15 @@ body {
 	margin-bottom: 8px;
 }
 
+.quirk-desc_hint {
+	color: #f1d669;
+	font-size: 9px;
+	line-height: 1.4;
+	margin-bottom: 8px;
+	font-style: italic;
+	text-align: center;
+}
+
 .quirk-status {
 	font-size: 11px;
 	color: #4CAF50;

--- a/html/browser/quirk_menu.css
+++ b/html/browser/quirk_menu.css
@@ -284,7 +284,6 @@ body {
 	font-size: 9px;
 	line-height: 1.4;
 	margin-bottom: 8px;
-	font-style: italic;
 	text-align: center;
 }
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Добавлена переменная `desc_hint` для квирков. Должно использоваться для контекстной информации, не описывающей квирк.
   - `desc_hint` добавлено в регистр квирков.
   - `get_desc_hint()` прок добавлен для вывода переменной.
   - `dat +=` строки добавлены для отображения в преференс-меню.
   - Добавлен .css стиль `.quirk-desc_hint`.
- Квирки:
   - Получили свои `desc_hint` где было нужно.
   - Квирк Lux-Less был убран через `/*`.
### ENG
- Added var `desc_hint` for quirks. Must be used for context non-desc quirk info.
   - `desc_hint` was added to init quirk registry.
   - `get_desc_hint()` proc was added for variable return.
   - `dat +=` lines of named variable were added for preferences menu.
   - .css style `.quirk-desc_hint` were added for the variable.
- Quirks:
   - Got their `desc_hint` variable where needed.
   - Quirk Lux-Less were removed.

## Why It's Good For The Game
- Добавляет стилистической вариативности с целью облегчить восприятие информации игроком и дробленим информации на удобные абзацы.
- Lux-Less не нужен специфике билда Rivermist Hollow

### ENG
- Adds style variativity for user-friendly perseption of non-desc quirk texts.
- Lux-Less isn't needed for Rivenmist Hollow build.
<details>
<img width="466" height="119" alt="muted" src="https://github.com/user-attachments/assets/44b74fc6-0b75-45d0-bc87-e8194e7474a7" />
<img width="465" height="164" alt="wanted" src="https://github.com/user-attachments/assets/c348ea56-2de5-4f59-9ac7-aafad695830a" />
</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: `Desc_hint` variable was added as descriptor for non-desc quirk texts | Переменная `Desc_hint` добавлена для отображения не-описательных текстов квирков.
del: "Lux-Less" квирк был удалён | "Lux-Less" quirk were removed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
