### PR TITLE
No pouch vice rework

### DIFF
--- a/code/datums/quirks/vices/physical_vice.dm
+++ b/code/datums/quirks/vices/physical_vice.dm
@@ -521,12 +521,18 @@
 
 /datum/quirk/vice/nopouch
 	name = "No Pouch"
-	desc = "I lost my pouch recently, I'm without a zenny.."
+	desc = "I lost my pouch recently, I'm without an amna.."
 	point_value = 1
 
-/datum/quirk/vice/nopouch/on_spawn()
+/datum/quirk/vice/nopouch/after_job_spawn(datum/job/job)
 	var/mob/living/carbon/human/H = owner
-	var/obj/item/pouch = locate(/obj/item/storage/belt/pouch) in H
+	var/pouch = find_pouch(H)
+
+	if(!pouch)
+		penalize_points(span_warning("No pouch found! Amaunator removed some of your traits to compensate."))
+		return
+
+	// Pouch deletion if found
 	if(H.wear_neck == pouch)
 		H.wear_neck = null
 	if(H.beltl == pouch)
@@ -534,6 +540,17 @@
 	if(H.beltr == pouch)
 		H.beltr = null
 	qdel(pouch)
+	to_chat(H, span_warning("I've lost my pouch... Damn it..."))
+
+/// Proc to find pouch in inventory, including slots and containers like satchels
+/datum/quirk/vice/nopouch/proc/find_pouch(mob/living/carbon/human/H)
+	var/obj/item/storage/belt/pouch/inventory_pouch
+	for(inventory_pouch in H.contents)
+		return inventory_pouch
+	for(var/obj/item/storage/storages in H.contents)
+		for(inventory_pouch in storages.contents)
+			return inventory_pouch
+	return null
 
 /datum/quirk/vice/wild_night
 	name = "Wild Night"

--- a/modular_rmh/code/datums/quirks/_base_rmh.dm
+++ b/modular_rmh/code/datums/quirks/_base_rmh.dm
@@ -3,33 +3,40 @@
     return B.point_value - A.point_value
 
 /// Penalize player for picking quirks that don't affect them for some reason and give free points
+/// Penalizes a player for picking a vice that didn't affect them, removing boons to compensate
 /datum/quirk/proc/penalize_points(penalize_text = "")
 	var/mob/living/carbon/human/H = owner
 	if(!istype(H))
 		return
 
-	// Get all boons we have
-	var/list/boons = list()
+	var/list/boons = list() // Get all boons that the player has
 	for(var/datum/quirk/Q in H.quirks)
 		if(Q.quirk_category == QUIRK_BOON)
 			boons += Q
 	if(!length(boons))
 		return
 
-	// Remove the same amount of quirks that match our vice points
 	var/debt = abs(point_value)
 	sortTim(boons, /proc/cmp_quirk_cost)
-	while(debt > 0 && length(boons))
-		var/datum/quirk/first = boons[1]
-		var/min_cost = first.point_value
-		var/list/candidates = list()
-		for(var/datum/quirk/Q in boons)
-			if(Q.point_value == min_cost)
-				candidates += Q
-
-		var/datum/quirk/chosen = pick(candidates)
-		debt -= abs(chosen.point_value)
-		boons -= chosen
-		H.remove_quirk(chosen.type)
+	// Look for a boon that exactly covers the debt
+	var/datum/quirk/exact = null
+	for(var/datum/quirk/Q in boons)
+		if(abs(Q.point_value) == debt)
+			exact = Q
+			break
+	if(exact)
+		H.remove_quirk(exact.type)
+	else
+		// No exact match — remove cheapest boons until debt is covered
+		while(debt > 0 && length(boons))
+			var/datum/quirk/first = boons[1]
+			var/list/candidates = list()
+			for(var/datum/quirk/Q in boons)
+				if(Q.point_value == first.point_value)
+					candidates += Q
+			var/datum/quirk/chosen = pick(candidates)
+			debt -= abs(chosen.point_value)
+			boons -= chosen
+			H.remove_quirk(chosen.type)
 
 	to_chat(H, span_warning(penalize_text))

--- a/modular_rmh/code/datums/quirks/_base_rmh.dm
+++ b/modular_rmh/code/datums/quirks/_base_rmh.dm
@@ -1,0 +1,35 @@
+/// Counts quirk
+/proc/cmp_quirk_cost(datum/quirk/A, datum/quirk/B)
+    return B.point_value - A.point_value
+
+/// Penalize player for picking quirks that don't affect them for some reason and give free points
+/datum/quirk/proc/penalize_points(penalize_text = "")
+	var/mob/living/carbon/human/H = owner
+	if(!istype(H))
+		return
+
+	// Get all boons we have
+	var/list/boons = list()
+	for(var/datum/quirk/Q in H.quirks)
+		if(Q.quirk_category == QUIRK_BOON)
+			boons += Q
+	if(!length(boons))
+		return
+
+	// Remove the same amount of quirks that match our vice points
+	var/debt = abs(point_value)
+	sortTim(boons, /proc/cmp_quirk_cost)
+	while(debt > 0 && length(boons))
+		var/datum/quirk/first = boons[1]
+		var/min_cost = first.point_value
+		var/list/candidates = list()
+		for(var/datum/quirk/Q in boons)
+			if(Q.point_value == min_cost)
+				candidates += Q
+
+		var/datum/quirk/chosen = pick(candidates)
+		debt -= abs(chosen.point_value)
+		boons -= chosen
+		H.remove_quirk(chosen.type)
+
+	to_chat(H, span_warning(penalize_text))

--- a/vanderlin.dme
+++ b/vanderlin.dme
@@ -3940,6 +3940,7 @@
 #include "modular_rmh\code\datums\ai\horny_ai\horny_ai_datums.dm"
 #include "modular_rmh\code\datums\ai\horny_ai\horny_subtrees.dm"
 #include "modular_rmh\code\datums\components\darkling.dm"
+#include "modular_rmh\code\datums\quirks\_base_rmh.dm"
 #include "modular_rmh\code\datums\quirks\extra_genitals.dm"
 #include "modular_rmh\code\datums\quirks\rmh_quirks.dm"
 #include "modular_rmh\code\datums\religion\faiths\evil_gods.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Добавлен модульный `_base_rmh.dm` с двумя проками: счёта разницы цены проков и прок для отнимания boon за счёт `point_value` boon/vice квирка.
   - Игра ищет сумму очков по самым дешёвым квиркам для удаления.
   - Если у игрока есть boon, который ценой полностью покроет стоимость vice - игра удалит сначала его и проверит, покрыт ли штраф. Если нет - она удалит даже если штраф выйдет с запасом.
- Vice "No Pouch" был модифицирован.
   - Исправлено описание на амна.
   - `on_spawn()` заменён на `after_job_spawn()`.
   - Добавлена проверка отсутствия pouch, если после спавна таковой в инвентаре нет - наказать игроока отъёмом boon по цене этого vice.
   - Добавлен прок конкретно этого прока для поиска pouch не только на кукле, но и в её инвентаре-контейнерах, чтобы pouch'и, находящиеся в `backpack_content` аутфитов классов, также удалялись.

## Why It's Good For The Game
- Устраняет ситуацию, в которой игроки берут ради фрипоинтов этот vice.
   - Чинит ситуацию, когда фрипоинт оказывался даже если пауч есть, но в сумке.
   - Наказывает игрока за попытку взять халяву за счёт классов, которые раундстарт не имеют pouch с монетами.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
balance: 
fix: Vice "No pouch" will find pouch even in storage items of player, not only inventory slots | Недостаток "No pouch" найдёт pouch даже в предметах-хранилищах игрока, а не только слотов инвентаря.
code: Added two helder procs: for player penalizing if quirk condition coded; and quirks cost equasion proc | Добавлено два хелперских прока: для штрафования игрока если были прописаны в коде условия штрафа в квирке; и прок счёта суммы/разницы стоимости квирков.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
