### PR TITLE
NycteaLust-QoL№2

### DIFF
--- a/code/__DEFINES/traits/definitions.dm
+++ b/code/__DEFINES/traits/definitions.dm
@@ -425,6 +425,7 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define TRAIT_AMAZING_BACK "Light Load"
 #define TRAIT_KITTEN_MOM "Loved By Kittens"
 #define TRAIT_WATER_BREATHING "Waterbreathing"
+#define TRAIT_WATER_LOVER "WaterLover"
 #define TRAIT_MOONWATER_ELIXIR "Moonwater Elixir"
 #define TRAIT_FLOWERFIELD_IMMUNITY "Flower Strider"
 #define TRAIT_SECRET_OFFICIANT "Secret Officiant"

--- a/code/_globalvars/traits.dm
+++ b/code/_globalvars/traits.dm
@@ -177,6 +177,7 @@ GLOBAL_LIST_INIT(traits_by_type, list(
 		"Light Load" = TRAIT_AMAZING_BACK,
 		"Loved By Kittens" = TRAIT_KITTEN_MOM,
 		"Waterbreathing" = TRAIT_WATER_BREATHING,
+		"WaterLover" = TRAIT_WATER_LOVER,
 		"Moonwater Elixir" = TRAIT_MOONWATER_ELIXIR,
 		"Violator of the Coven" = TRAIT_VIOLATOR,
 		"Endless Slumber" = TRAIT_TORPOR,

--- a/code/datums/stress/positive_events.dm
+++ b/code/datums/stress/positive_events.dm
@@ -13,6 +13,11 @@
 	stress_change = -1
 	desc = span_green("Death. Hehe...")
 
+/datum/stress_event/wet_cloth_positive
+    stress_change = -1
+    desc = span_green("I am wearing wet clothes.. YAY.")
+    timer = 1 MINUTES
+
 /datum/stress_event/viewdismembermaniac
 	timer = 2 MINUTES
 	stress_change = -1

--- a/code/modules/cargo/supply_packs/weapons.dm
+++ b/code/modules/cargo/supply_packs/weapons.dm
@@ -280,17 +280,17 @@
 
 /datum/supply_pack/weapons/ranged/puffer
 	name = "Smuggled Püffer"
-	cost = 500
+	cost = 750
 	contains = /obj/item/gun/ballistic/revolver/grenadelauncher/pistol
 
 /datum/supply_pack/weapons/ranged/musket
 	name = "Smuggled Musket"
-	cost = 750 //needs balancing
+	cost = 1250 //needs balancing
 	contains = /obj/item/gun/ballistic/revolver/grenadelauncher/pistol/musket
 
 /datum/supply_pack/weapons/ranged/cannon
 	name = "Cannon"
-	cost = 800
+	cost = 1300
 	contains = /obj/structure/cannon
 
 /datum/supply_pack/weapons/ranged/crossbow

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -605,7 +605,10 @@ BLIND     // can't see anything
 	if(wet.water_stacks < 0)
 		if(COOLDOWN_FINISHED(src, wet_stress_cd))
 			COOLDOWN_START(src, wet_stress_cd, 60 SECONDS)
-			C.add_stress(/datum/stress_event/wet_cloth)
+			if(HAS_TRAIT(C, TRAIT_WATER_LOVER) || istriton(C))
+				C.add_stress(/datum/stress_event/wet_cloth_positive)
+			else
+				C.add_stress(/datum/stress_event/wet_cloth)
 
 /obj/item/clothing/take_damage(damage_amount, damage_type, damage_flag, sound_effect, attack_dir, armor_penetration)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
+++ b/code/modules/mob/living/carbon/human/species_types/triton/_triton.dm
@@ -55,7 +55,7 @@
 	use_skintones = TRUE
 
 	species_traits = list(NO_UNDERWEAR, HAIR, FACEHAIR, OLDGREY)
-	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_WATER_BREATHING, TRAIT_GOOD_SWIM)
+	inherent_traits = list(TRAIT_NOMOBSWAP, TRAIT_WATER_BREATHING, TRAIT_GOOD_SWIM, TRAIT_WATER_LOVER)
 	inherent_traits_m = list(TRAIT_STRONGBITE)
 	inherent_sheet = /datum/attribute_holder/sheet/job/species/triton/inherent
 

--- a/code/modules/spells/spell_types/undirected/conjure_item/puffer.dm
+++ b/code/modules/spells/spell_types/undirected/conjure_item/puffer.dm
@@ -5,10 +5,10 @@
 	sound = 'sound/magic/whiteflame.ogg'
 
 	associated_skill = /datum/attribute/skill/magic/holy
-	cooldown_time = 2 MINUTES
+	cooldown_time = 6 MINUTES
 	invocation_type = INVOCATION_NONE
 	item_type = /obj/item/gun/ballistic/revolver/grenadelauncher/pistol/conjured
 	item_duration = null
 	item_outline ="#ababab"
 	spell_type = SPELL_STAMINA //It is a way to balance it out since you are not a real miracle user.
-	spell_cost = 40
+	spell_cost = 80


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request

Добавлен трейт "WaterLover" - Убирает дебафф от ношения мокрой одежды и дает небольшой мудбафф, в будущем постараюсь сделать мудбафф от воды и дождя.
Трейт "WaterLover" - выдан Тритонам
Подняла цены на огнестрел, пока немного посмотрим в игре.
Теперь заклинание Conjure Puffer - требует больше выносливости и перезаряжается дольше (6 минут вместо 2 и 80 стамины вместо 40)

Added the "WaterLover" trait - Removes the debuff from wearing wet clothes and gives a small mudbuff, in the future I will try to make mudbuff from water and rain.
Trait "WaterLover" - issued to Newts
I raised the prices of firearms, while we look at the game a little bit.
Conjure Puffer spell now requires more stamina and takes longer to recharge (6 minutes instead of 2 and 80 stamina instead of 40)
## Why It's Good For The Game

Странно что тритоны и водные расы получают дебафф от воды, огнестрел слишком доступный это не хорошо.
Заклинание Puffer сильное и при этом не требует ни долгой зарядки ни имела долгой перезарядки, теперь чуть более баланс.

It's strange that newts and aquatic races get a debuff from water, firearms that are too affordable are not good.
The Puffer spell is strong and does not require either a long charge or a very long recharge, now it is slightly more balanced.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
