### PR TITLE
Cloak rain protection system

### DIFF
--- a/code/datums/particle_weathers/datum_types/rain.dm
+++ b/code/datums/particle_weathers/datum_types/rain.dm
@@ -25,13 +25,26 @@
 	if(can_weather_effect(L))
 		weather_act(L)
 		var/mob/living/carbon/C = L
-		if(!istype(C))
+		if(!iscarbon(C))
 			return
-		var/obj/item/clothing/head/hooded/rainhood = C.head
-		if(!istype(rainhood))
-			C.SoakMob(FULL_BODY, dirty_water = FALSE, rain = TRUE)
-		else
+		var/mob/living/carbon/human/H = C
+		var/obj/item/clothing/cloak/cloak_on_body = null
+		if(ishuman(C))
+			cloak_on_body = H.cloak
+
+		var/has_hood = istype(C.head, /obj/item/clothing/head/hooded) || istype(C.head, /obj/item/clothing/head/roguehood)
+		var/cloak_protection = cloak_on_body?.is_rain_protective
+
+		if(has_hood && cloak_protection)
 			C.SoakMob(FEET, dirty_water = FALSE, rain = TRUE)
+		else if(cloak_protection)
+			C.SoakMob(FULL_HEAD, dirty_water = FALSE, rain = TRUE)
+			C.SoakMob(FEET, dirty_water = FALSE, rain = TRUE)
+		else if(has_hood)
+			C.SoakMob(CHEST, dirty_water = FALSE, rain = TRUE)
+			C.SoakMob(FEET, dirty_water = FALSE, rain = TRUE)
+		else
+			C.SoakMob(FULL_BODY, dirty_water = FALSE, rain = TRUE)
 
 /datum/particle_weather/rain/rain_gentle
 	name = "Rain"

--- a/code/datums/stress/negative_events.dm
+++ b/code/datums/stress/negative_events.dm
@@ -301,7 +301,7 @@
 /datum/stress_event/coldhead
 	timer = 60 SECONDS
 	stress_change = 1
-//	desc = "<span class='red'>My head is cold and ugly.</span>"
+	desc = span_red("My head is cold and ugly.")
 
 /datum/stress_event/sleepytime
 	timer = 0

--- a/code/modules/clothing/cloak/_cloak.dm
+++ b/code/modules/clothing/cloak/_cloak.dm
@@ -18,3 +18,5 @@
 	grid_width = 64
 	grid_height = 64
 	item_weight = 350 GRAMS
+
+	var/is_rain_protective = FALSE

--- a/code/modules/clothing/cloak/cape.dm
+++ b/code/modules/clothing/cloak/cape.dm
@@ -12,6 +12,7 @@
 	nodismemsleeves = TRUE
 	inhand_mod = FALSE
 	slot_flags = ITEM_SLOT_BACK_R | ITEM_SLOT_CLOAK
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/cape/colored
 	misc_flags = CRAFTING_TEST_EXCLUDE

--- a/code/modules/clothing/cloak/misc.dm
+++ b/code/modules/clothing/cloak/misc.dm
@@ -40,6 +40,7 @@
 	sellprice = 50
 	nodismemsleeves = TRUE
 	min_cold_protection_temperature = -20
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/tribal
 	name = "tribal pelt"
@@ -54,6 +55,7 @@
 	nodismemsleeves = TRUE
 	boobed = FALSE
 	sellprice = 10
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/heartfelt
 	name = "red cloak"
@@ -67,6 +69,7 @@
 	allowed_race = SPECIES_BASE_BODY
 	sellprice = 50
 	nodismemsleeves = TRUE
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/half
 	name = "half cloak"
@@ -86,6 +89,7 @@
 	color = CLOTHING_SOOT_BLACK
 	allowed_sex = list(MALE, FEMALE)
 	allowed_race = SPECIES_BASE_BODY
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/half/Initialize(mapload, ...)
 	. = ..()
@@ -165,6 +169,7 @@
 	sleevetype = "shirt"
 	slot_flags = ITEM_SLOT_CLOAK | ITEM_SLOT_BACK_R
 	nodismemsleeves = TRUE
+	is_rain_protective = TRUE
 
 //............... Battle Nun ........................... (unique kit for the role, tabard for aesthetics)
 /obj/item/clothing/cloak/battlenun
@@ -227,6 +232,7 @@
 	nodismemsleeves = TRUE
 	inhand_mod = FALSE
 	slot_flags = ITEM_SLOT_BACK_R|ITEM_SLOT_CLOAK
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/wickercloak
 	name = "wicker cloak"
@@ -240,6 +246,7 @@
 	nodismemsleeves = TRUE
 	inhand_mod = TRUE
 	allowed_race = SPECIES_BASE_BODY
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/faceless
 	name = "sash"
@@ -268,6 +275,7 @@
 	mob_overlay_icon = 'icons/roguetown/clothing/special/onmob/evilarmor.dmi'
 	sleeved = 'icons/roguetown/clothing/special/onmob/evilarmor.dmi'
 	sellprice = 0 // See above comment
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/silktabard
 	name = "fine silk tabard"
@@ -306,6 +314,7 @@
 	item_state = "poncho"
 	boobed = FALSE
 	sleeved = 'icons/roguetown/clothing/onmob/cloaks.dmi'
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/pantheon
 	name = "pantheon cloak"

--- a/code/modules/clothing/cloak/raincloak.dm
+++ b/code/modules/clothing/cloak/raincloak.dm
@@ -19,6 +19,7 @@
 	salvage_result = /obj/item/natural/hide/cured
 	color = CLOTHING_BARK_BROWN
 	wetable = FALSE
+	is_rain_protective = TRUE
 
 /obj/item/clothing/cloak/raincloak/Initialize(mapload, ...)
 	. = ..()
@@ -71,6 +72,7 @@
 	resistance_flags = FLAMMABLE
 	flags_inv = HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDETAIL //hide tail for more anonimity
 	block2add = FOV_BEHIND
+	wetable = FALSE
 
 /obj/item/clothing/head/hooded/equipped(mob/user, slot)
 	. = ..()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -266,7 +266,7 @@
 	for(var/bp in body_parts)
 		if(!bp)
 			continue
-		if(bp && istype(bp , /obj/item/clothing))
+		if(istype(bp , /obj/item/clothing))
 			var/obj/item/clothing/C = bp
 			if(zone2covered(BODY_ZONE_HEAD, C.body_parts_covered))
 				coverhead = TRUE
@@ -289,10 +289,10 @@
 			var/obj/item/clothing/C = shoes
 			if(C && C.wetable)
 				C.wet.add_water(20, dirty_water)
-		else
+		else if(!rain || (locations & BELOW_CHEST))
 			var/list/below_chest = list(wear_pants, shoes)
 			for(var/obj/item/clothing/C in below_chest)
-				if(C.wetable)
+				if(C && C.wetable)
 					C.wet.add_water(20, dirty_water)
 
 //This proc returns a number made up of the flags for body parts which you are protected on. (such as HEAD, CHEST, GROIN, etc. See setup.dm for the full list)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Система дождя была расширена для определения плаща/капюшона на мобе для проверок `SoakMob()`.
   - Голова может намокнуть для стресс-ивента `Coldhead` отдельно от тела, если надет плащ.
- Стресс-ивент `Coldhead` теперь отображает описание игроку.
- Плащи, накидки и кое-какие вариации теперь имеют переменную `is_rain_protective` для погодных проверок.
- `SoakMob()` прок карбонов был немного оптимизирован и модифицирован для учёта дождя как источника, для намоканий от погоды.

### ENG
- Rain system extended in the part of cloak & hood detection on a mob for `SoakMob()` runs.
   - A head can be wetted with `Coldhead` stress event separately from body wetting if cloak is worn.
- `Coldhead` stress event is now have its desc enabled.
- Cloaks, capes and some other variations are now have variable `is_rain_protective` for weather runs.
- `SoakMob()` for carbons were slighty optimized and modified to check for the rain source, for weather soak proper work.

TODO: spells/alchemy that would be making `is_rain_protective_` as TRUE for cloak items.


## Why It's Good For The Game
- Это устраняет проблему намокания в таких айтемах как "Raincoat", которые из названия и описания ДОЛЖНЫ защищать от дождя юзера.

### ENG
- That deals with wetting problem with such item as "Raincoat" that MUST protect from rain wetting via name & desc.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
add: Raincoats, some capes and variations are now protecting from rains | Плащи, накидки и кое-какие вариации теперь защищают от дождя.
fix: Coldhead stress event is now displaying for player after head wetting. | Coldhead стресс-ивент теперь показывается игроку после намокания у головы.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
