### PR TITLE
Changed genderbender potion

### DIFF
--- a/code/modules/crafting/alchemy/reagents.dm
+++ b/code/modules/crafting/alchemy/reagents.dm
@@ -145,7 +145,7 @@
 	metabolization_rate = REAGENTS_METABOLISM * 5
 	alpha = 173
 
-/datum/reagent/medicine/gender_potion/on_mob_life(mob/living/carbon/M, efficiency)
+/datum/reagent/medicine/gender_potion/reaction_mob(mob/living/M, method, reac_volume, show_message, touch_protection, target_zone)
 	if(!M.get_erp_pref(/datum/erp_preference/boolean/allow_gender_bender))
 		to_chat(M, span_warning("Your body refuses the potion!"))
 		return
@@ -164,7 +164,9 @@
 		old_gender = FEMALE
 		M.gender = MALE
 		M.visible_message(span_boldnotice("[M] suddenly looks more masculine!"), span_boldwarning("You suddenly feel more masculine!"))
-	M.dna?.species?.on_gender_update(M, old_gender)
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		C.dna?.species?.on_gender_update(C, old_gender)
 	M.apply_gender_potion_genital_change(old_gender)
 	M.regenerate_icons()
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

## About The Pull Request
- Прок `on_mob_life()` зелья смены пола заменено на единично и мгновенно просчитываемый `reaction_mob()`.
- Добавлена проверка на карбона перед ДНК-проверками

### ENG
- Genderbender potion metabolism `on_mob_life()` proc was changed into `reaction_mob()` instant proc.
- Added carbon check into checks for DNA checks.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This fixes an issue for `to_chat()` spam for player during reagent metabolism. The potion have one single puprose of changing the gender of affected target mob, no need to check it tick-vise.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

<!-- !! Do not add whitespace in-between the entries, do not change the tags and do not leave the tags without any entries. -->
:cl:
qol: Genderbender potion is now reaction mob based instead of metabolism | Зелье смены пола теперь основано на мгновенном применении вместо метаболизма.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->
